### PR TITLE
Move consistency assertion into `Index::find_locations()`

### DIFF
--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -139,12 +139,16 @@ impl Index {
         Ok(stats)
     }
 
-    pub fn find_positions(
+    pub fn find_locations(
         &self,
         script_hash: &index::ScriptHash,
         from: index::TxPos,
-    ) -> Result<Vec<index::TxPos>, Error> {
-        Ok(self.store.scan(script_hash, from)?)
+    ) -> Result<impl Iterator<Item = Location>, Error> {
+        Ok(self
+            .store
+            .scan(script_hash, from)?
+            // chain and store must be in sync
+            .map(|txpos| self.chain.find_by_txpos(&txpos).expect("invalid position")))
     }
 
     pub fn get_tx_bytes(&self, location: &Location) -> Result<Vec<u8>, Error> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -149,9 +149,9 @@ impl Store {
         &self,
         script_hash: &index::ScriptHash,
         from: index::TxPos,
-    ) -> Result<Vec<index::TxPos>, rocksdb::Error> {
+    ) -> Result<impl Iterator<Item = index::TxPos>, rocksdb::Error> {
         let cf = self.cf(SCRIPT_HASH_CF);
-        let mut result = vec![];
+        let mut positions = Vec::new();
 
         let prefix = index::ScriptHashPrefix::new(script_hash);
         let start = index::ScriptHashPrefixRow::new(prefix, from);
@@ -163,9 +163,9 @@ impl Store {
             }
             let row = index::ScriptHashPrefixRow::from_bytes(key[..].try_into().unwrap());
             assert!(row.txpos() >= from);
-            result.push(row.txpos());
+            positions.push(row.txpos());
         }
-        Ok(result)
+        Ok(positions.into_iter())
     }
 
     pub fn headers(&self) -> Result<Vec<index::Header>, rocksdb::Error> {


### PR DESCRIPTION
We assume that RocksDB index is constient with in-memory chain.