### PR TITLE
Fast bulk transaction fetching for history reconstruction

### DIFF
--- a/bindex-lib/src/chain.rs
+++ b/bindex-lib/src/chain.rs
@@ -32,7 +32,14 @@ pub enum Error {
 
     #[error("block not found: {0}")]
     BlockNotFound(#[from] headers::Reorg),
+
+    #[error("thread pool failed: {0}")]
+    ThreadPool(#[from] rayon::ThreadPoolBuildError),
 }
+
+/// Concurrent REST fetches are IO-bound: size the pool to bitcoind's HTTP
+/// worker-thread count rather than this process' CPU quota.
+const FETCH_THREADS: usize = 16;
 
 #[derive(Debug)]
 pub struct Stats {
@@ -58,6 +65,7 @@ pub struct IndexedChain {
     headers: headers::Headers,
     client: client::Client,
     store: db::DB,
+    fetch_pool: rayon::ThreadPool,
 }
 
 #[derive(Debug)]
@@ -155,6 +163,10 @@ impl IndexedChain {
         let agent = ureq::Agent::new_with_config(
             ureq::config::Config::builder()
                 .max_response_header_size(usize::MAX) // Disabled as a workaround
+                // keep a warm connection per fetch thread (the defaults would
+                // drop most of them between concurrent bursts)
+                .max_idle_connections(FETCH_THREADS)
+                .max_idle_connections_per_host(FETCH_THREADS)
                 .build(),
         );
         let client = client::Client::new(agent, config.url);
@@ -192,11 +204,16 @@ impl IndexedChain {
                 headers.tip_height().unwrap(),
             );
         }
+        let fetch_pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(FETCH_THREADS)
+            .thread_name(|i| format!("fetch{}", i))
+            .build()?;
         Ok(IndexedChain {
             genesis_hash,
             headers,
             client,
             store,
+            fetch_pool,
         })
     }
 
@@ -352,6 +369,18 @@ impl IndexedChain {
         Ok(self
             .client
             .get_block_part(location.indexed_header.hash(), pos)?)
+    }
+
+    /// Fetch multiple transactions' bytes from bitcoind concurrently.
+    /// Results are returned in the input locations' order.
+    pub fn get_txs_bytes(&self, locations: &[Location]) -> Result<Vec<Vec<u8>>, Error> {
+        use rayon::prelude::*;
+        self.fetch_pool.install(|| {
+            locations
+                .par_iter()
+                .map(|location| self.get_tx_bytes(location))
+                .collect()
+        })
     }
 
     pub fn headers(&self) -> &headers::Headers {

--- a/bindex-lib/src/chain.rs
+++ b/bindex-lib/src/chain.rs
@@ -41,6 +41,70 @@ pub enum Error {
 /// worker-thread count rather than this process' CPU quota.
 const FETCH_THREADS: usize = 16;
 
+/// Merging nearby same-block transactions into one blockpart request pays
+/// while the bytes between them cost less to transfer than a request
+/// round-trip (~0.5ms ≈ ~100KB at the measured ~200MB/s per stream);
+/// split spans at gaps clearly above that.
+const COALESCE_GAP_LIMIT: u32 = 256 * 1024;
+
+/// One blockpart request covering a run of nearby transactions of a single
+/// block; items record each transaction's result index and span-relative
+/// position.
+struct FetchSpan {
+    hash: BlockHash,
+    pos: index::TxBlockPos,
+    items: Vec<(usize, index::TxBlockPos)>,
+}
+
+impl FetchSpan {
+    fn new(hash: BlockHash, index: usize, pos: index::TxBlockPos) -> Self {
+        Self {
+            hash,
+            pos,
+            items: vec![(
+                index,
+                index::TxBlockPos {
+                    offset: 0,
+                    size: pos.size,
+                },
+            )],
+        }
+    }
+
+    /// Extend with a nearby following transaction of the same block;
+    /// returns false when it belongs in a new span.
+    fn try_extend(&mut self, hash: BlockHash, index: usize, pos: index::TxBlockPos) -> bool {
+        let end = self.pos.offset + self.pos.size;
+        if hash != self.hash || pos.offset < end || pos.offset - end > COALESCE_GAP_LIMIT {
+            return false;
+        }
+        let offset = pos.offset - self.pos.offset;
+        self.pos.size = offset + pos.size;
+        self.items.push((
+            index,
+            index::TxBlockPos {
+                offset,
+                size: pos.size,
+            },
+        ));
+        true
+    }
+
+    /// Fetch the span and slice out each transaction with its result index.
+    fn fetch(&self, client: &client::Client) -> Result<Vec<(usize, Vec<u8>)>, Error> {
+        let bytes = client.get_block_part(self.hash, self.pos)?;
+        assert_eq!(bytes.len(), self.pos.size as usize);
+        Ok(self
+            .items
+            .iter()
+            .map(|&(index, pos)| {
+                let begin = pos.offset as usize;
+                (index, bytes[begin..begin + pos.size as usize].to_vec())
+            })
+            .collect())
+    }
+}
+
 #[derive(Debug)]
 pub struct Stats {
     pub tip: bitcoin::BlockHash,
@@ -371,16 +435,42 @@ impl IndexedChain {
             .get_block_part(location.indexed_header.hash(), pos)?)
     }
 
-    /// Fetch multiple transactions' bytes from bitcoind concurrently.
-    /// Results are returned in the input locations' order.
+    /// Group locations into blockpart spans, one per run of nearby
+    /// same-block transactions (locations arrive in txnum order, so those
+    /// are consecutive with ascending offsets).
+    fn coalesce_spans(&self, locations: &[Location]) -> Result<Vec<FetchSpan>, Error> {
+        let mut spans: Vec<FetchSpan> = Vec::new();
+        for (index, location) in locations.iter().enumerate() {
+            let hash = location.indexed_header.hash();
+            let pos = self.store.get_tx_block_pos(location.txnum)?;
+            let extended = spans
+                .last_mut()
+                .is_some_and(|span| span.try_extend(hash, index, pos));
+            if !extended {
+                spans.push(FetchSpan::new(hash, index, pos));
+            }
+        }
+        Ok(spans)
+    }
+
+    /// Fetch multiple transactions' bytes from bitcoind concurrently,
+    /// coalescing nearby same-block transactions into single blockpart
+    /// requests. Results are returned in the input locations' order.
     pub fn get_txs_bytes(&self, locations: &[Location]) -> Result<Vec<Vec<u8>>, Error> {
         use rayon::prelude::*;
-        self.fetch_pool.install(|| {
-            locations
+
+        let spans = self.coalesce_spans(locations)?;
+        let fetched = self.fetch_pool.install(|| {
+            spans
                 .par_iter()
-                .map(|location| self.get_tx_bytes(location))
-                .collect()
-        })
+                .map(|span| span.fetch(&self.client))
+                .collect::<Result<Vec<_>, Error>>()
+        })?;
+        let mut result = vec![Vec::new(); locations.len()];
+        for (index, bytes) in fetched.into_iter().flatten() {
+            result[index] = bytes;
+        }
+        Ok(result)
     }
 
     pub fn headers(&self) -> &headers::Headers {
@@ -497,6 +587,14 @@ mod tests {
             .unwrap()
             .collect();
         assert_eq!(locations, vec![loc2]);
+
+        // bulk fetch matches per-location fetch (nearby same-block
+        // transactions — e.g. tx1 & tx2 above — coalesce into one request)
+        let bulk = chain.get_txs_bytes(&txs).unwrap();
+        assert_eq!(bulk.len(), txs.len());
+        for (location, bytes) in txs.iter().zip(&bulk) {
+            assert_eq!(bytes, &chain.get_tx_bytes(location).unwrap());
+        }
 
         // check reorg
         let old_tip = get_tip();

--- a/bindex-lib/src/chain.rs
+++ b/bindex-lib/src/chain.rs
@@ -439,10 +439,27 @@ impl IndexedChain {
     /// same-block transactions (locations arrive in txnum order, so those
     /// are consecutive with ascending offsets).
     fn coalesce_spans(&self, locations: &[Location]) -> Result<Vec<FetchSpan>, Error> {
+        use rayon::prelude::*;
+
+        // Concurrent batched position lookups: per-transaction lookups cost
+        // an iterator + seek each, which dominates whale-sized fetches;
+        // batches share one iterator and reuse each row for all the nearby
+        // transactions it covers.
+        const LOOKUP_BATCH: usize = 64;
+        let batches: Vec<Vec<index::TxBlockPos>> = self.fetch_pool.install(|| {
+            locations
+                .par_chunks(LOOKUP_BATCH)
+                .map(|batch| {
+                    let txnums: Vec<_> = batch.iter().map(|location| location.txnum).collect();
+                    self.store.get_tx_block_poses(&txnums)
+                })
+                .collect::<Result<_, _>>()
+        })?;
+        let positions: Vec<index::TxBlockPos> = batches.into_iter().flatten().collect();
+
         let mut spans: Vec<FetchSpan> = Vec::new();
-        for (index, location) in locations.iter().enumerate() {
+        for (index, (location, &pos)) in locations.iter().zip(&positions).enumerate() {
             let hash = location.indexed_header.hash();
-            let pos = self.store.get_tx_block_pos(location.txnum)?;
             let extended = spans
                 .last_mut()
                 .is_some_and(|span| span.try_extend(hash, index, pos));

--- a/bindex-lib/src/db.rs
+++ b/bindex-lib/src/db.rs
@@ -245,17 +245,35 @@ impl DB {
         &self,
         txnum: index::TxNum,
     ) -> Result<index::TxBlockPos, rocksdb::Error> {
-        let cf = self.cf(TXPOS_CF);
+        let mut poses = self.get_tx_block_poses(&[txnum])?;
+        Ok(poses
+            .pop()
+            .expect("get_tx_block_poses should return one position per txnum"))
+    }
 
-        let from_key = txnum.serialize();
-        let mode = rocksdb::IteratorMode::From(&from_key, rocksdb::Direction::Forward);
-        if let Some(kv) = self.db.iterator_cf(cf, mode).next() {
-            let (key, value) = kv?;
-            assert!(from_key[..] <= key[..]);
-            let row = TxBlockPosRow::deserialize(&key, &value);
-            return Ok(row.get_tx_block_pos(txnum));
+    /// Positions for ascending `txnums`: one forward iterator serves the
+    /// whole batch, and a row is deserialized once for all the txnums it
+    /// covers (a fresh iterator + seek per lookup dominates otherwise).
+    pub fn get_tx_block_poses(
+        &self,
+        txnums: &[index::TxNum],
+    ) -> Result<Vec<index::TxBlockPos>, rocksdb::Error> {
+        let cf = self.cf(TXPOS_CF);
+        let mut iter = self.db.raw_iterator_cf(cf);
+        let mut row: Option<TxBlockPosRow> = None;
+        let mut result = Vec::with_capacity(txnums.len());
+        for &txnum in txnums {
+            if !row.as_ref().is_some_and(|row| row.contains(txnum)) {
+                iter.seek(txnum.serialize());
+                iter.status()?;
+                let kv = iter.key().zip(iter.value());
+                let (key, value) = kv.unwrap_or_else(|| panic!("Missing {:?}", txnum));
+                row = Some(TxBlockPosRow::deserialize(key, value));
+            }
+            let row = row.as_ref().expect("row should be set by the seek above");
+            result.push(row.get_tx_block_pos(txnum));
         }
-        panic!("Missing {:?}", txnum)
+        Ok(result)
     }
 
     /// Load all headers from DB.

--- a/bindex-lib/src/index/txpos.rs
+++ b/bindex-lib/src/index/txpos.rs
@@ -134,6 +134,13 @@ impl TxBlockPosRow {
             .collect()
     }
 
+    /// Whether `txnum`'s position is stored in this row.
+    pub fn contains(&self, txnum: TxNum) -> bool {
+        self.last_txnum
+            .offset_from(txnum)
+            .is_some_and(|delta| (delta as usize) < self.offsets.0.len() - 1)
+    }
+
     pub fn get_tx_block_pos(&self, txnum: TxNum) -> TxBlockPos {
         let last_index = self.offsets.0.len().checked_sub(1).expect("empty Offsets");
         let delta_from_last = self.last_txnum.offset_from(txnum).expect("TxNum too large") as usize;

--- a/bindex-lib/src/lib.rs
+++ b/bindex-lib/src/lib.rs
@@ -12,7 +12,7 @@ mod index;
 
 pub use chain::IndexedChain;
 pub use headers::Headers;
-pub use index::ScriptHash;
+pub use index::{IndexedHeader, ScriptHash};
 
 #[derive(PartialEq, Eq, PartialOrd, Clone, Copy, Debug)]
 pub struct Location<'a> {


### PR DESCRIPTION
Reconstructing a scripthash history costs one REST roundtrip (plus one
RocksDB `txpos` lookup) per transaction, serially — measured ~0.55 ms
per request against a local bitcoind v31, so large histories take
minutes. This series makes the per-transaction work concurrent,
coalesces nearby same-block transactions into single `blockpart`
requests, and batches the `txpos` lookups.

Measured step by step on
`bc1qryhgpmfv03qjhhp2dj8nw8g4ewg08jzmgy3cyx` (813k history entries,
6.5 per block on average) — electrs built on bindex, RK3588 host,
bitcoind on the same machine:

| change | wall clock |
|---|---:|
| baseline (serial per-transaction fetch) | 446 s |
| `get_txs_bytes`: concurrent fetching (16-wide) | 51 s |
| coalesce nearby same-block transactions | 29 s |
| batch + parallelize `txpos` lookups | **17 s** |

The genesis address `1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa` (65k
entries) went 74 s → 4.3 s through the same series; scripthashes with
a few thousand entries or fewer stay sub-second throughout.

### What the series does

1. **`chain: concurrent transaction fetching (get_txs_bytes)`** — an
   order-preserving bulk fetch API over a dedicated 16-thread pool.
   The pool is sized to bitcoind's HTTP worker count rather than the
   CPU quota (the work is IO-bound), and the ureq agent keeps a warm
   connection per thread. The single-location `get_tx_bytes` is
   unchanged.
2. **`lib: export IndexedHeader`** — consumers already hold it (via
   `Headers::get_header` / `locations_by_scripthash`) but could not
   name its type.
3. **`chain: coalesce nearby same-block transactions`** — measured on
   the address above: same-block entries are typically *adjacent*
   transactions (batch payouts; median gap zero bytes), so one
   blockpart request per run of nearby transactions cuts the request
   count ~6.5× at negligible byte amplification. Spans split at gaps
   over 256 KB, where transferring the gap would cost more than the
   saved round-trip (~0.5 ms fixed + ~5 µs/KB, measured).
4. **`db: batch and parallelize position lookups`** — a perf profile
   showed the remaining time in `txpos` reads: `get_tx_block_pos`
   builds a fresh RocksDB iterator and seeks per call, and adjacent
   transactions re-seek into the row just decoded and discarded.
   `get_tx_block_poses` serves ascending txnums with one forward
   iterator per batch, deserializing each row once for all the txnums
   it covers; the single-txnum lookup now delegates to it.

### Notes

- No schema or on-disk change; `get_txs_bytes` is additive and
  results are returned in input order, so existing callers are
  unaffected.
- `FETCH_THREADS` (16) and `COALESCE_GAP_LIMIT` (256 KB) are
  constants with their rationale documented inline — happy to make
  either configurable if you prefer.
- Correctness is pinned by extending `test_chain_bitcoind`: bulk
  results are compared byte-for-byte against per-location
  `get_tx_bytes` over a set spanning many blocks, including a
  same-block pair that exercises coalescing.
- `cargo test -p bindex --lib` green (including the corepc-node
  integration tests), no new clippy/rustfmt findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
